### PR TITLE
Use custom datatypes in database schema

### DIFF
--- a/src/Database.hs
+++ b/src/Database.hs
@@ -39,6 +39,9 @@ newtype Account =
     { _account :: Text
     } deriving (Show, Eq)
 
+instance BeamMigrateSqlBackend be => HasDefaultSqlDataType be Account where
+  defaultSqlDataType = defaultSqlDataType . fmap _account
+
 instance HasSqlValueSyntax be Text => HasSqlValueSyntax be Account where
   sqlValueSyntax = sqlValueSyntax . _account
 

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -15,8 +18,12 @@ import Database.Beam.Migrate
 import Database.Beam.Migrate.Simple
 import Database.Beam.Sqlite
 import Database.Beam.Sqlite.Migrate
+import Database.Beam.Sqlite.Syntax
+import Database.Beam.Backend.SQL
 import Database.SQLite.Simple (Connection)
 
+import Data.Time.Clock
+import Data.Time.Calendar
 import Data.Time.LocalTime
 
 data NotificationPercent =
@@ -27,10 +34,26 @@ data NotificationPercent =
   | Hundred
   deriving (Eq, Ord, Show)
 
+newtype Account =
+  Account
+    { _account :: Text
+    } deriving (Show, Eq)
+
+instance HasSqlValueSyntax be Text => HasSqlValueSyntax be Account where
+  sqlValueSyntax = sqlValueSyntax . _account
+
+instance FromBackendRow Sqlite Account where
+  fromBackendRow = Account <$> fromBackendRow
+
+newtype ServiceUnits =
+  ServiceUnits
+    { _serviceUnits :: Integer
+    } deriving (Show, Eq)
+
 data ProposalT f =
   Proposal
     { _proposalId :: Columnar f Integer
-    , _proposalAccount :: Columnar f Text
+    , _proposalAccount :: Columnar f Account
     , _proposalServiceUnits :: Columnar f Integer
     , _proposalEndDate :: Columnar f LocalTime
     , _proposalNotificationProgress :: Columnar f Text

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -48,6 +48,9 @@ instance HasSqlValueSyntax be Text => HasSqlValueSyntax be Account where
 instance FromBackendRow Sqlite Account where
   fromBackendRow = Account <$> fromBackendRow
 
+accountDataType :: DataType Sqlite Account
+accountDataType = DataType sqliteTextType
+
 newtype ServiceUnits =
   ServiceUnits
     { _serviceUnits :: Integer
@@ -93,7 +96,7 @@ initialSetup = ProposalDb <$>
   (createTable "proposals" $
     Proposal
       { _proposalId = field "id" int notNull unique
-      , _proposalAccount = field "account" (varchar Nothing) notNull
+      , _proposalAccount = field "account" accountDataType
       , _proposalServiceUnits = field "serviceUnits" int notNull
       , _proposalEndDate = field "endDate" timestamptz notNull
       , _proposalNotificationProgress = field "notificationProgress" (varchar Nothing) notNull


### PR DESCRIPTION
Add `Account` and `ServiceUnits` newtypes to the database schema. Includes various instances to make all of this work.